### PR TITLE
fix(hook): OnBeforeInitTalentForLevel

### DIFF
--- a/modules/mod-timewalking/src/scripts/TimeWalking.cpp
+++ b/modules/mod-timewalking/src/scripts/TimeWalking.cpp
@@ -703,7 +703,7 @@ public:
         sAzthUtils->updateTwLevel(player, player->GetGroup());
     }
 
-    void OnBeforeInitTalentForLevel(Player* player, uint8&  /*level*/, uint32& talentPointsForLevel) override
+    void OnBeforeInitTalentForLevel(Player* player, uint32& talentPointsForLevel) override
     {
         if (!sAzthUtils->isMythicLevel(sAZTH->GetAZTHPlayer(player)->GetTimeWalkingLevel()) // redundant (?)
             && (sAZTH->GetAZTHPlayer(player)->isTimeWalking(true) || sAZTH->GetAZTHPlayer(player)->GetTimeWalkingLevel() == TIMEWALKING_LVL_AUTO) )


### PR DESCRIPTION
This is a sister PR to https://github.com/azerothcore/azerothcore-wotlk/pull/7389 to fix the usage of this hook within this module as it's used for testing builds. 

Prior to this the hook wasn't fired at all so probably dead code here but might as well make it fit.